### PR TITLE
Align parameter names in header & implementation

### DIFF
--- a/src/psl.h
+++ b/src/psl.h
@@ -94,7 +94,7 @@ namespace Url
          * Add the provided host with the provided priority, trimming characters off
          * the front, and adjusting the level by the provided number.
          */
-        void add(std::string& host, int level_adjust, size_t trim);
+        void add(std::string& rule, int level_adjust, size_t trim);
     };
 
 }


### PR DESCRIPTION
From `clang-tidy` `readability-inconsistent-declaration-parameter-name`:

https://clang.llvm.org/extra/clang-tidy/checks/readability/inconsistent-declaration-parameter-name.html

c.f.

https://github.com/MichaelChirico/spiderbar/blob/66a2723990b6e79cabe19ae608f3fcb0837e3efb/src/psl.cpp#L170