### PR TITLE
Use == directly to compare strings

### DIFF
--- a/src/punycode.cpp
+++ b/src/punycode.cpp
@@ -341,7 +341,7 @@ namespace Url
         while(true)
         {
             std::string segment = hostname.substr(start, end - start);
-            if (segment.substr(0, 4).compare("xn--") == 0)
+            if (segment.substr(0, 4) == "xn--")
             {
                 segment = segment.substr(4);
                 unencoded.append(Punycode::decode(segment));


### PR DESCRIPTION
From `clang-tidy`'s `readability-string-compare`:

https://clang.llvm.org/extra/clang-tidy/checks/readability/string-compare.html