### PR TITLE
Avoid copy in loop

### DIFF
--- a/src/repmain.cpp
+++ b/src/repmain.cpp
@@ -31,7 +31,7 @@ DataFrame rep_crawl_delays(SEXP xp) {
   agents.reserve(ptr->agents_.size());
   vals.reserve(ptr->agents_.size());
 
-  for(auto kv : ptr->agents_) {
+  for(const auto& kv : ptr->agents_) {
     agents.push_back(kv.first);
     vals.push_back(kv.second.delay());
   }


### PR DESCRIPTION
From `clang-tidy`'s `performance-for-range-copy`:

https://clang.llvm.org/extra/clang-tidy/checks/performance/for-range-copy.html